### PR TITLE
fix shebang in hbd2tex.py

### DIFF
--- a/hbd2tex.py
+++ b/hbd2tex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2017 Diomidis Spinellis
 #


### PR DESCRIPTION
If we don't that some systems resolve `python` as python3, which breaks the script.